### PR TITLE
Add Blocking/Interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,17 @@
 
 ## Bump Script
 
-You can use the bump script if you already have the definitions file or a rippled build
+You can use the bump script if you already have the definitions file or a rippled build. The script will merge your definition with this repo.
 
 python3 bump.py | action | name | path
 
 - `python3 bump.py definitions Hooks ./definitions.json`
 - `python3 bump.py rippled Hooks ./rippled`
 
-> This will update the `README.md` and the `map.json` file.
+If you would like to know what sfields your rippled build is missing then run with:
+
+- `IS_DEBUG=True python3 bump.py definitions Hooks ./rippled`
+
 
 ## UINT16
 Type 1

--- a/README.md
+++ b/README.md
@@ -18,13 +18,6 @@ python3 bump.py | action | name | path
 
 > This will update the `README.md` and the `map.json` file.
 
-## NOTPRESENT
-Type 0
-
-|Field Code|Field Name|Used by|Reserved by|
-|-|-|-|-|
-
-
 ## UINT16
 Type 1
 
@@ -347,34 +340,6 @@ Type 19
 |2|Hashes|Ledger|n/a|
 |3|Amendments|Ledger|n/a|
 |4|NFTokenOffers|XLS20|n/a|
-
-
-## UINT96
-Type 20
-
-|Field Code|Field Name|Used by|Reserved by|
-|-|-|-|-|
-
-
-## UINT192
-Type 21
-
-|Field Code|Field Name|Used by|Reserved by|
-|-|-|-|-|
-
-
-## UINT384
-Type 22
-
-|Field Code|Field Name|Used by|Reserved by|
-|-|-|-|-|
-
-
-## UINT512
-Type 23
-
-|Field Code|Field Name|Used by|Reserved by|
-|-|-|-|-|
 
 
 ## ISSUE

--- a/bump.py
+++ b/bump.py
@@ -141,6 +141,8 @@ python3 bump.py | action | name | path
 
 """
     for k, v in new_type_map.items():
+        if len(v.items()) == 0:
+            continue
         type_nth: str = types[k]
         output_value += f'## {k.upper()}'
         output_value += '\n'

--- a/map.json
+++ b/map.json
@@ -1,5 +1,33 @@
 {
     "types": {
+        "Done": -1,
+        "Unknown": -2,
+        "NotPresent": 0,
+        "UInt16": 1,
+        "UInt32": 2,
+        "UInt64": 3,
+        "Hash128": 4,
+        "Hash256": 5,
+        "Amount": 6,
+        "Blob": 7,
+        "AccountID": 8,
+        "STObject": 14,
+        "STArray": 15,
+        "UInt8": 16,
+        "Hash160": 17,
+        "PathSet": 18,
+        "Vector256": 19,
+        "UInt96": 20,
+        "UInt192": 21,
+        "UInt384": 22,
+        "UInt512": 23,
+        "Transaction": 10001,
+        "LedgerEntry": 10002,
+        "Validation": 10003,
+        "Metadata": 10004,
+        "Issue": 24
+    },
+    "type_map": {
         "NotPresent": {},
         "UInt16": {
             "1": "|1|LedgerEntryType|Ledger|n/a|",
@@ -264,7 +292,7 @@
             "4": "|4|Asset2|XLS30|n/a|"
         }
     },
-    "results": {
+    "result_map": {
         "-399": "|-399|telLOCAL_ERROR|v1.10.0|n/a|",
         "-398": "|-398|telBAD_DOMAIN|v1.10.0|n/a|",
         "-397": "|-397|telBAD_PATH_COUNT|v1.10.0|n/a|",


### PR DESCRIPTION
The bump script will now error out if a merge conflict occurs. It will also overwrite any existing fields in the registry but not in your repo.

1. If a type, field or result is missing in your repo, the registry will alert you of the name, nth and type that is missing.
2. If a field/result in your repo exists in the registry, and the name is different, you will get not be able to continue until the conflict is resolved.